### PR TITLE
Add URL normalization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,6 +266,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ tracing = { version = "0.1", default-features = false }
 tracing-subscriber = { version = "0.3", default-features = false, features = [
     "fmt",
 ] }
+url = { version = "2.5.4", default-features = false }
 
 [profile.release]
 opt-level = "z"

--- a/src/commands/compact.rs
+++ b/src/commands/compact.rs
@@ -6,13 +6,15 @@ use asimov_snapshot::Snapshotter;
 use clientele::{StandardOptions, SysexitsError};
 use color_print::ceprintln;
 
+use crate::url::normalize_url;
+
 #[tokio::main]
 pub async fn compact(urls: &[String], _flags: &StandardOptions) -> Result<(), SysexitsError> {
     let storage = asimov_snapshot::storage::Fs::for_dir(asimov_root().join("snapshots"))?;
     let ss = Snapshotter::new(Resolver::new(), storage);
 
     let urls: Vec<String> = if !urls.is_empty() {
-        urls.into()
+        urls.into_iter().map(|url| normalize_url(url)).collect()
     } else {
         ss.list()
             .await

--- a/src/commands/compact.rs
+++ b/src/commands/compact.rs
@@ -11,8 +11,19 @@ pub async fn compact(urls: &[String], _flags: &StandardOptions) -> Result<(), Sy
     let storage = asimov_snapshot::storage::Fs::for_dir(asimov_root().join("snapshots"))?;
     let ss = Snapshotter::new(Resolver::new(), storage);
 
+    let urls: Vec<String> = if !urls.is_empty() {
+        urls.into()
+    } else {
+        ss.list()
+            .await
+            .inspect_err(|e| ceprintln!("<s,r>error:</> failed to list URLs: {e}"))?
+            .into_iter()
+            .map(|(url, _)| url)
+            .collect()
+    };
+
     for url in urls {
-        ss.compact(url).await.inspect_err(|e| {
+        ss.compact(&url).await.inspect_err(|e| {
             ceprintln!("<s,r>error:</> failed to compact snapshots for `{url}`: {e}")
         })?;
     }

--- a/src/commands/log.rs
+++ b/src/commands/log.rs
@@ -7,7 +7,7 @@ use clientele::{StandardOptions, SysexitsError};
 use color_print::{ceprintln, cprintln};
 use jiff::{Zoned, tz::TimeZone};
 
-use crate::timestamps::format_ts_diff;
+use crate::{timestamps::format_ts_diff, url::normalize_url};
 
 #[tokio::main]
 pub async fn log(url: &str, _flags: &StandardOptions) -> Result<(), SysexitsError> {
@@ -21,8 +21,9 @@ pub async fn log(url: &str, _flags: &StandardOptions) -> Result<(), SysexitsErro
 
     let now = Zoned::now();
     for ts in snapshots {
-        let data = ss.read(url, ts).await.inspect_err(|e| {
-            ceprintln!("<s,r>error:</> failed to read snapshot `{ts}` for url `{url}`: {e}")
+        let url = normalize_url(url);
+        let data = ss.read(&url, ts).await.inspect_err(|e| {
+            ceprintln!("<s,r>error:</> failed to read snapshot `{ts}` for URL `{url}`: {e}")
         })?;
 
         let hash = <sha2::Sha256 as sha2::Digest>::digest(&data);

--- a/src/commands/snapshot.rs
+++ b/src/commands/snapshot.rs
@@ -10,6 +10,8 @@ use clientele::{
 };
 use color_print::ceprintln;
 
+use crate::url::normalize_url;
+
 #[tokio::main]
 pub async fn snapshot(urls: &[String], _flags: &StandardOptions) -> Result<(), SysexitsError> {
     let storage = asimov_snapshot::storage::Fs::for_dir(asimov_root().join("snapshots"))?;
@@ -25,7 +27,8 @@ pub async fn snapshot(urls: &[String], _flags: &StandardOptions) -> Result<(), S
     let mut ss = Snapshotter::new(resolver, storage);
 
     for url in urls {
-        ss.snapshot(url).await.inspect_err(|e| {
+        let url = normalize_url(url);
+        ss.snapshot(&url).await.inspect_err(|e| {
             ceprintln!("<s,r>error:</> failed to snapshot the resource `{url}`: {e}")
         })?;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,3 +4,4 @@ pub mod commands;
 pub mod features;
 
 pub(crate) mod timestamps;
+pub(crate) mod url;

--- a/src/url.rs
+++ b/src/url.rs
@@ -1,0 +1,58 @@
+// This is free and unencumbered software released into the public domain.
+
+pub fn normalize_url(url: &str) -> String {
+    // test whether it's a normal, valid, URL
+    if let Ok(url) = <url::Url>::parse(url) {
+        return url.to_string();
+    };
+
+    // all the below cases treat the url as a file path.
+
+    // replace a `~/` prefix with the path to the user's home dir.
+    let url = url
+        .strip_prefix("~/")
+        .map(|path| {
+            std::env::home_dir()
+                .expect("unable to determine home directory")
+                .join(path)
+        })
+        .unwrap_or_else(|| std::path::PathBuf::from(url));
+
+    // `std::path::Path::canonicalize`:
+    // > Returns the canonical, absolute form of the path with all
+    // > intermediate components normalized and symbolic links resolved.
+    //
+    // This will only work if the file actually exists.
+    if let Ok(path) = std::path::Path::new(&url)
+        .canonicalize()
+        .map_err(|_| ())
+        .and_then(url::Url::from_file_path)
+    {
+        return path.to_string();
+    };
+
+    // `std::path::absolute`:
+    // > Makes the path absolute without accessing the filesystem.
+    if let Ok(path) = std::path::absolute(&url)
+        .map_err(|_| ())
+        .and_then(url::Url::from_file_path)
+    {
+        return path.to_string();
+    }
+
+    // TODO: add `std::path::Path::normalize_lexically` once it stabilizes.
+    // https://github.com/rust-lang/rust/issues/134694
+    //
+    // if let Ok(path) = std::path::Path::new(url).normalize_lexically() {
+    //     return url::Url::from_file_path(path).unwrap().to_string();
+    // }
+
+    // one last try, test whether the `url` crate accepts it as path without changes.
+    if let Ok(path) = url::Url::from_file_path(std::path::Path::new(&url)) {
+        return path.to_string();
+    }
+
+    // otherwise just convert to a file URL without changes and hope for the best :)
+    // (we should not really get here but just in case.)
+    format!("file://{}", url.display())
+}


### PR DESCRIPTION
- Adds a copy of the implementation from `asimov-cli` for URL normalization
- Command `compact` will compact snapshots of each saved URL if none given as CLI arg

Will update with a proper reimplementation for the URL normalization once I get that working.

@race-of-sloths